### PR TITLE
chore: replace the slack url to updated invite url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in Keploy and for taking the time to contribute to this project. 🙌
 Keploy is a project by developers for developers and there are a lot of ways you can contribute.
-If you don't know where to start contributing, ask us on our [Slack channel](https://join.slack.com/t/keploy/shared_invite/zt-357qqm9b5-PbZRVu3Yt2rJIa6ofrwWNg).
+If you don't know where to start contributing, ask us on our [Slack channel](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA).
 
 ## Code of conduct
 

--- a/css/main.css
+++ b/css/main.css
@@ -3920,16 +3920,14 @@ html.no-csstransitions .home-content__main {
 }
 
 .join-btn{
+    display: inline-block;
     margin:0 auto;
     background-color: #00163D;
     border-radius: 5px;
-    color:#FF914D;
+    color: white;
     outline: none;
     border:0px;
-}
-
-.join-btn a{
-    color:white
+    text-decoration: none;
 }
 
 .countdown-timer{

--- a/css/main.css
+++ b/css/main.css
@@ -3922,12 +3922,17 @@ html.no-csstransitions .home-content__main {
 .join-btn{
     display: inline-block;
     margin:0 auto;
+    padding: 6px 16px;
     background-color: #00163D;
     border-radius: 5px;
     color: white;
-    outline: none;
     border:0px;
     text-decoration: none;
+}
+
+.join-btn:focus-visible{
+    outline: 2px solid #FF914D;
+    outline-offset: 2px;
 }
 
 .countdown-timer{

--- a/index.html
+++ b/index.html
@@ -237,7 +237,7 @@
                 <a href="https://forms.gle/R7RbuL39sc1TFW449" class=" btn btn--stroke" style="background: #F89559; border: 0.2rem solid #ff904d; color: #00163D;">
                 Register Now!
                 </a>
-                <a href="https://join.slack.com/t/keploy/shared_invite/zt-357qqm9b5-PbZRVu3Yt2rJIa6ofrwWNg" class="btn btn--stroke" style="background: #00163D; border: 0.2rem solid #00163D; color: #FFFFFF;">
+                <a href="https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA" class="btn btn--stroke" style="background: #00163D; border: 0.2rem solid #00163D; color: #FFFFFF;">
                 Join Community
                 </a>
               </div>
@@ -734,7 +734,7 @@
               <h3 class="h6" style="font-size: 2rem; font-family: 'Inconsolata', monospace; text-transform: none;">Get Involved In The Community Today!</h3>
               <img src="./images/slack.png" alt="Slack Image"/>
               <!-- <img src="./images/slack2.png"/> -->
-              <button class="join-btn"><a href="https://join.slack.com/t/keploy/shared_invite/zt-357qqm9b5-PbZRVu3Yt2rJIa6ofrwWNg">Join Slack</a></button>
+              <button class="join-btn"><a href="https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA">Join Slack</a></button>
             </div>
             <!-- end contact-primary -->
             <div class="contact-secondary">

--- a/index.html
+++ b/index.html
@@ -734,7 +734,7 @@
               <h3 class="h6" style="font-size: 2rem; font-family: 'Inconsolata', monospace; text-transform: none;">Get Involved In The Community Today!</h3>
               <img src="./images/slack.png" alt="Slack Image"/>
               <!-- <img src="./images/slack2.png"/> -->
-              <button class="join-btn"><a href="https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA">Join Slack</a></button>
+              <a href="https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA" class="join-btn">Join Slack</a>
             </div>
             <!-- end contact-primary -->
             <div class="contact-secondary">


### PR DESCRIPTION
## Description

Updates the Slack community invite URL across the repository to the new active invite link.

Fixes the expired/old Slack invite `zt-357qqm9b5-PbZRVu3Yt2rJIa6ofrwWNg` and replaces it with the updated invite `zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Manually verified all occurrences of the old invite URL were replaced by running a repo-wide search. Confirmed the new URL appears correctly in all 3 locations.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) by adding `--signoff` to my git commit command
