### PR TITLE
chore: replace the temp slack url to permanent route

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in Keploy and for taking the time to contribute to this project. 🙌
 Keploy is a project by developers for developers and there are a lot of ways you can contribute.
-If you don't know where to start contributing, ask us on our [Slack channel](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA).
+If you don't know where to start contributing, ask us on our [Slack channel](https://keploy.io/slack).
 
 ## Code of conduct
 

--- a/index.html
+++ b/index.html
@@ -207,7 +207,7 @@
                 <!-- <li><a class="smoothscroll"  href="#join" title="join">Join</a></li> -->
               </ul>
               <ul class="header-nav__social">
-                <li><a href="https://keploy.io/slack"><i class="fa-brands fa-slack"></i></a></li>
+                <li><a href="https://keploy.io/slack" aria-label="Join our Slack community"><i class="fa-brands fa-slack"></i></a></li>
                 <li><a href="https://twitter.com/Keployio"><i class="fa-brands fa-x-twitter"></i></a></li>
                 <li><a href="https://www.youtube.com/channel/UC6OTg7F4o0WkmNtSoob34lg"><i class="fa-brands fa-youtube"></i></a></li>
                 <li><a href="https://www.linkedin.com/company/keploy/"><i class="fa-brands fa-linkedin"></i></a></li>
@@ -744,7 +744,7 @@
                   <h2 style="color:#ffffff;">Connect with writers, mentors, and enthusiasts worldwide who share a passion for crafting content and exploring the layers of technology!</h5>
                 </div>
                 <ul class="contact-social">
-                  <li><a href="https://keploy.io/slack" style="color: white;"><i class="fa-brands fa-slack"></i></a></li>
+                  <li><a href="https://keploy.io/slack" aria-label="Join our Slack community" style="color: white;"><i class="fa-brands fa-slack"></i></a></li>
                   <li><a href="https://twitter.com/Keployio" style="color: white;"><i class="fa-brands fa-x-twitter"></i></a></li>
                   <li><a href="https://www.youtube.com/channel/UC6OTg7F4o0WkmNtSoob34lg" style="color: white;"><i class="fa-brands fa-youtube"></i></a></li>
                   <li><a href="https://www.linkedin.com/company/keploy/" style="color: white;"><i class="fa-brands fa-linkedin"></i></a></li>
@@ -823,7 +823,7 @@
                   </div>
                   <p style="font-family:'Inconsolata', monospace;">Let us be social</p>
                   <ul class="list" style="margin-left:0">
-                    <li><a href="https://keploy.io/slack"><i class="fa-brands fa-slack"></i></a></li>
+                    <li><a href="https://keploy.io/slack" aria-label="Join our Slack community"><i class="fa-brands fa-slack"></i></a></li>
                     <li><a href="https://twitter.com/Keployio"><i class="fa-brands fa-x-twitter"></i></a></li>
                     <li><a href="https://www.youtube.com/channel/UC6OTg7F4o0WkmNtSoob34lg"><i class="fa-brands fa-youtube"></i></a></li>
                     <li><a href="https://www.linkedin.com/company/keploy/"><i class="fa-brands fa-linkedin"></i></a></li>

--- a/index.html
+++ b/index.html
@@ -207,7 +207,7 @@
                 <!-- <li><a class="smoothscroll"  href="#join" title="join">Join</a></li> -->
               </ul>
               <ul class="header-nav__social">
-                <li><a href="https://keploy.slack.com/"><i class="fa-brands fa-slack"></i></a></li>
+                <li><a href="https://keploy.io/slack"><i class="fa-brands fa-slack"></i></a></li>
                 <li><a href="https://twitter.com/Keployio"><i class="fa-brands fa-x-twitter"></i></a></li>
                 <li><a href="https://www.youtube.com/channel/UC6OTg7F4o0WkmNtSoob34lg"><i class="fa-brands fa-youtube"></i></a></li>
                 <li><a href="https://www.linkedin.com/company/keploy/"><i class="fa-brands fa-linkedin"></i></a></li>
@@ -237,7 +237,7 @@
                 <a href="https://forms.gle/R7RbuL39sc1TFW449" class=" btn btn--stroke" style="background: #F89559; border: 0.2rem solid #ff904d; color: #00163D;">
                 Register Now!
                 </a>
-                <a href="https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA" class="btn btn--stroke" style="background: #00163D; border: 0.2rem solid #00163D; color: #FFFFFF;">
+                <a href="https://keploy.io/slack" class="btn btn--stroke" style="background: #00163D; border: 0.2rem solid #00163D; color: #FFFFFF;">
                 Join Community
                 </a>
               </div>
@@ -258,7 +258,7 @@
           <!-- end home-content -->
           <ul class="home-social">
             <li>
-              <a href="https://keploy.slack.com/"><i class="fa-brands fa-slack" aria-hidden="true"></i><span>Slack</span></a>
+              <a href="https://keploy.io/slack"><i class="fa-brands fa-slack" aria-hidden="true"></i><span>Slack</span></a>
             </li>
             <li>
               <a href="https://twitter.com/Keployio"><i class="fa-brands fa-x-twitter" aria-hidden="true"></i><span>Twitter</span></a>
@@ -734,7 +734,7 @@
               <h3 class="h6" style="font-size: 2rem; font-family: 'Inconsolata', monospace; text-transform: none;">Get Involved In The Community Today!</h3>
               <img src="./images/slack.png" alt="Slack Image"/>
               <!-- <img src="./images/slack2.png"/> -->
-              <a href="https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA" class="join-btn">Join Slack</a>
+              <a href="https://keploy.io/slack" class="join-btn">Join Slack</a>
             </div>
             <!-- end contact-primary -->
             <div class="contact-secondary">
@@ -744,7 +744,7 @@
                   <h2 style="color:#ffffff;">Connect with writers, mentors, and enthusiasts worldwide who share a passion for crafting content and exploring the layers of technology!</h5>
                 </div>
                 <ul class="contact-social">
-                  <li><a href="https://keploy.slack.com/" style="color: white;"><i class="fa-brands fa-slack"></i></a></li>
+                  <li><a href="https://keploy.io/slack" style="color: white;"><i class="fa-brands fa-slack"></i></a></li>
                   <li><a href="https://twitter.com/Keployio" style="color: white;"><i class="fa-brands fa-x-twitter"></i></a></li>
                   <li><a href="https://www.youtube.com/channel/UC6OTg7F4o0WkmNtSoob34lg" style="color: white;"><i class="fa-brands fa-youtube"></i></a></li>
                   <li><a href="https://www.linkedin.com/company/keploy/" style="color: white;"><i class="fa-brands fa-linkedin"></i></a></li>
@@ -823,7 +823,7 @@
                   </div>
                   <p style="font-family:'Inconsolata', monospace;">Let us be social</p>
                   <ul class="list" style="margin-left:0">
-                    <li><a href="https://keploy.slack.com/"><i class="fa-brands fa-slack"></i></a></li>
+                    <li><a href="https://keploy.io/slack"><i class="fa-brands fa-slack"></i></a></li>
                     <li><a href="https://twitter.com/Keployio"><i class="fa-brands fa-x-twitter"></i></a></li>
                     <li><a href="https://www.youtube.com/channel/UC6OTg7F4o0WkmNtSoob34lg"><i class="fa-brands fa-youtube"></i></a></li>
                     <li><a href="https://www.linkedin.com/company/keploy/"><i class="fa-brands fa-linkedin"></i></a></li>


### PR DESCRIPTION
This PR replaces all temporary and outdated Slack invite links with the permanent, simplified Keploy Slack route (`https://keploy.io/slack`).

## Changes

- Updated the Slack community link in `CONTRIBUTING.md`.
- Updated all social and community Slack references across `index.html` to point directly to the new Keploy Slack URL.

This ensures a unified and consistent entry point to the Keploy community for all users, contributors, and writers.